### PR TITLE
1.4.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,16 @@ const replaceWithInlineElement = (compilation, tag) => {
   return newTag;
 };
 
-const getScriptName = (tag) => tag.attributes.src;
+const getScriptName = (tag) => {
+  let scriptName = tag.attributes.src;
+
+  // remove publicPath prefix
+  if (scriptName.includes('/')) {
+    scriptName = scriptName.replace(/^.*\//, '');
+  }
+
+  return scriptName;
+};
 
 const updateSrcElement = (options, tag) => {
   const scriptName = getScriptName(tag);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-ext-html-webpack-plugin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Enhances html-webpack-plugin functionality with async and defer attributes for script elements",
   "main": "index.js",
   "files": [

--- a/spec/core-spec.js
+++ b/spec/core-spec.js
@@ -357,4 +357,18 @@ describe(`Core functionality (webpack ${version.webpack})`, function () {
     ];
     testPlugin(config, expected, done);
   });
+
+  it('inline scripts work with output.publicPath', done => {
+    const config = baseConfig(
+      {
+        inline: ['a']
+      }
+    );
+    config.output.publicPath = '/subdomain/';
+    const expected = baseExpectations();
+    expected.html = [
+      /(<script>[\s\S]*<\/script>)/
+    ];
+    testPlugin(config, expected, done);
+  });
 });

--- a/spec/core-spec.js
+++ b/spec/core-spec.js
@@ -301,7 +301,7 @@ describe(`Core functionality (webpack ${version.webpack})`, function () {
     testPlugin(config, expected, done);
   });
 
-  it('named stylesheets work with output.publicPath', done => {
+  it('named scripts work with output.publicPath', done => {
     const config = baseConfig(
       {
         sync: ['a.js'],
@@ -319,7 +319,7 @@ describe(`Core functionality (webpack ${version.webpack})`, function () {
     testPlugin(config, expected, done);
   });
 
-  it('muliple merged stylesheets work with output.publicPath', done => {
+  it('muliple merged scripts work with output.publicPath', done => {
     const config = baseConfig(
       {
         async: ['main']


### PR DESCRIPTION
Thanks for creating `script-ext-html-webpack-plugin`! This PR adds support for using the `inline` option alongside a `publicPath` webpack configuration, corrects a few spec descriptions, and bumps a patch version for release.