### PR TITLE
fix error in Windows caused by separator

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const debug = require('debug')('ScriptExt');
-const separator = require('path').sep;
+const separator = require('path').posix.sep;
 
 const isScript = (tag) => tag.tagName === 'script';
 


### PR DESCRIPTION
It will throw an error when i used 1.8.3 in windows. I found that is caused by the Windows separator.

![image](https://user-images.githubusercontent.com/13999774/27679720-17cb809c-5cec-11e7-9307-f1a1d5ba8cd8.png)
