### PR TITLE
Fix combining inlining and custom attributes

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -7,7 +7,7 @@ const isScript = (tag) => tag.tagName === 'script';
 
 const hasScriptName = tag => tag.attributes && tag.attributes.src;
 
-const getRawScriptName = tag => tag.attributes.src;
+const getRawScriptName = tag => tag.attributes && tag.attributes.src || '';
 
 const getPublicPath = options => {
   const output = options.compilationOptions.output;


### PR DESCRIPTION
Inlined scripts were `<script>` tags whose `tag.attributes` property was `undefined`, and therefore `tag.attributes.src` was throwing an `Uncaught TypeError: Cannot read property 'src' of undefined`. 

This change fallbacks script tags without attributes to use an empty string, technically allowing inlined script tags to still have custom attributes added (using a RegExp test for an empty string: `/^$/`).