### PR TITLE
add custom attribute support for preload/prefetch

### DIFF
--- a/lib/async-chunk-resource-hints.js
+++ b/lib/async-chunk-resource-hints.js
@@ -16,9 +16,9 @@ const addAsyncChunkResourceHints = (chunks, options) => {
       [])
     .forEach(file => {
       if (optionsMatch(options.preload, file)) {
-        hints.push(createResourceHint('preload', getRef(file)));
+        hints.push(createResourceHint('preload', getRef(file), options.preload.attrs));
       } else if (optionsMatch(options.prefetch, file)) {
-        hints.push(createResourceHint('prefetch', getRef(file)));
+        hints.push(createResourceHint('prefetch', getRef(file), options.prefetch.attrs));
       }
     });
   return hints;

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,7 +7,8 @@ const DEFAULT_HASH = {
 };
 const DEFAULT_RESOURCE_HINT_HASH = {
   test: [],
-  chunks: 'initial'
+  chunks: 'initial',
+  attrs: {}
 };
 const DEFAULT_CUSTOM_HASH = {
   test: [],
@@ -26,7 +27,7 @@ const DEFAULT_OPTIONS = {
   removeInlinedAssets: true,
   custom: []
 };
-const POSSIBLE_VALUES = ['chunks', 'attribute', 'value'];
+const POSSIBLE_VALUES = ['chunks', 'attribute', 'value', 'attrs'];
 
 const normaliseOptions = options => {
   if (!options) return DEFAULT_OPTIONS;

--- a/lib/initial-chunk-resource-hints.js
+++ b/lib/initial-chunk-resource-hints.js
@@ -19,9 +19,9 @@ const addInitialChunkResourceHints = (options, tags) => {
     .reduce((hints, tag) => {
       const scriptName = getScriptName(options, tag);
       if (optionsMatch(options.preload, scriptName)) {
-        hints.push(createResourceHint('preload', getRawScriptName(tag)));
+        hints.push(createResourceHint('preload', getRawScriptName(tag), options.preload.attrs));
       } else if (optionsMatch(options.prefetch, scriptName)) {
-        hints.push(createResourceHint('prefetch', getRawScriptName(tag)));
+        hints.push(createResourceHint('prefetch', getRawScriptName(tag), options.prefetch.attrs));
       }
       return hints;
     },

--- a/lib/resource-hints.js
+++ b/lib/resource-hints.js
@@ -5,15 +5,15 @@ const shouldAddResourceHints = options => {
            options.preload.test.length === 0);
 };
 
-const createResourceHint = (rel, href) => {
+const createResourceHint = (rel, href, attrs) => {
   return {
     tagName: 'link',
     selfClosingTag: true,
-    attributes: {
+    attributes: Object.assign({}, attrs, {
       rel: rel,
       href: href,
       as: 'script'
-    }
+    })
   };
 };
 


### PR DESCRIPTION
When maintain a large web application, we need to deploy static assets on CDN, which has a different origin against our web domain. So in order to use tools like sentry to track js errors, we need to add `crossorigin="anonymous"` attribute on scripts.

However, when use **preload/prefetch** feature of **script-ext-html-webpack-plugin**, the output `<link />` don't contain `crossorigin="anonymous"`, which will cause **double fetches**.

```
<link ref="preload" as="script" href="//a-cdn-server.com/some-script.js" />
...
<script src="//a-cdn-server.com/some-script.js" crossorigin="anonymous"></script>
```

This PR is try to add a feature to support custom attributes for link tag.

example:
```
plugins: [
  new HtmlWebpackPlugin(),
  new ScriptExtHtmlWebpackPlugin({
      custom: {
        test: /\.js$/,
        attribute: 'crossorigin',
        value: 'anonymous'
      },
      preload: {
        test: /\.js$/,
        attrs: {
          crossorigin: 'anonymous'
        }
      }
  })
]  
```