### PR TITLE
handle the runtime failure with latest cra

### DIFF
--- a/lib/elements.js
+++ b/lib/elements.js
@@ -66,6 +66,10 @@ const updateSrcElement = (options, tag) => {
     }
   });
   if (!newAttribute) newAttribute = options.defaultAttribute;
+
+  // if the attributes key is undefined, we initialize it
+  if (!tag.attributes) tag.attributes = {}
+
   if (newAttribute !== SYNC) {
     tag.attributes[newAttribute] = true;
   }

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -67,7 +67,6 @@ const updateSrcElement = (options, tag) => {
   });
   if (!newAttribute) newAttribute = options.defaultAttribute;
 
-  // if the attributes key is undefined, we initialize it
   if (!tag.attributes) tag.attributes = {}
 
   if (newAttribute !== SYNC) {


### PR DESCRIPTION
When tried using the script on CRA setup with multi setup, this plugin fails with below error. This fix adds a defensive check when the attributes key is empty.

```yarn run v1.22.10
$ NODE_ENV=production react-app-rewired build
Creating an optimized production build...
Failed to compile.

Cannot set property 'defer' of undefined
```

Deps:
"react-app-rewire-multiple-entry": "^2.2.0",
"react-app-rewired": "^2.1.6",
"react-scripts": "4.0.0",